### PR TITLE
Update example README to reflect S3 naming restrictions

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -10,3 +10,9 @@ Most (if not) all of them can be deployed to your AWS account by simply running:
 
 Some of them like ``dynamodb``, ``kinesis`` and ``s3`` require you to configure
 the source stream/bucket to be one that you own, obviously.
+
+AWS Resource Notes
+------------------
+
+* Ensure your S3 bucket name is globally unique, not just to your account.
+  See [S3 bucket documentation](http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html) for details.


### PR DESCRIPTION
I believe this will tackle the documentation gap mentioned in #9. Let me know if I missed any other documentation opportunities in the repo as I have not familiarized myself with all of it yet.