### PR TITLE
adding in ability to define extra alias for a lambda if desired

### DIFF
--- a/docs/lambdas.rst
+++ b/docs/lambdas.rst
@@ -95,6 +95,7 @@ The following is the anatomy of a lambda in gordon.
       auto-vpc-policy: { BOOLEAN }
       auto-run-policy: { BOOLEAN }
       cli-output: { BOOLEAN }
+      alias: { STRING }
       policies:
         { POLICY_NAME }:
           { MAP }
@@ -534,6 +535,17 @@ Required                     No
 Default                      True
 Valid types                  ``boolean``
 Description                  Output the lambda ARN as part of the ``apply`` output
+===========================  ============================================================================================================
+
+
+alias
+^^^^^^^^^^^^^^^^^^^^^^
+
+===========================  ============================================================================================================
+Name                         ``alias``
+Required                     No
+Valid types                  ``string,(?!^[0-9]+$)([a-zA-Z0-9-_]+)``
+Description                  Creates an alias for the lambda version being deployed in addition to ``current``
 ===========================  ============================================================================================================
 
 

--- a/gordon/resources/lambdas.py
+++ b/gordon/resources/lambdas.py
@@ -303,6 +303,24 @@ class Lambda(base.BaseResource):
             )
         )
 
+        # Add a custom alias if the setting is configured
+        if self.settings.get("alias"):
+            template.add_resource(
+                awslambda.Alias(
+                    self.current_alias_cf_name,
+                    DependsOn=[
+                        version.name
+                    ],
+                    FunctionName=troposphere.Ref(
+                        function
+                    ),
+                    FunctionVersion=troposphere.GetAtt(
+                        version, "Version"
+                    ),
+                    Name=self.settings.get("alias"),
+                )
+            )
+
         alias = template.add_resource(
             awslambda.Alias(
                 self.current_alias_cf_name,


### PR DESCRIPTION
Hey I was needing a way to add a custom alias for a deployment of lambdas, so this seemed the right place to put it, but I really just wanted to get the conversation going. As I'm just learning the code base I'm not sure which place would be most appropriate to add unit test coverage tests/base/tests.py and add a 0004_*.json with an addition of an alias resource?
