### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![gordon](http://gordon.readthedocs.io/en/latest/_static/logo_text.svg)
+![gordon](https://gordon.readthedocs.io/en/latest/_static/logo_text.svg)
 
 [![GitHub license](https://img.shields.io/badge/license-BSD-blue.svg)](COPYING)
 ![Python Versions](https://img.shields.io/badge/python-2.7%20%7C%203.3%20%7C%203.4%20%7C%203.5-green.svg)
@@ -10,7 +10,7 @@
 
 Gordon is a tool to create, wire and deploy AWS Lambdas using CloudFormation
 
-Documentation: http://gordon.readthedocs.io/en/latest/
+Documentation: https://gordon.readthedocs.io/en/latest/
 
 Features
 ---------

--- a/docs/_build/html/_sources/requirements.txt
+++ b/docs/_build/html/_sources/requirements.txt
@@ -27,7 +27,7 @@ file in the root of your lambda folder, and gordon will install all those using 
 
 For more information about the format of this file:
 
-    * https://pip.readthedocs.org/en/1.1/requirements.html
+    * https://pip.readthedocs.io/en/1.1/requirements.html
 
 Additionally you can customize how gordon invoques ``pip`` using the following settings:
 

--- a/docs/_build/html/_sources/setup_aws.txt
+++ b/docs/_build/html/_sources/setup_aws.txt
@@ -5,4 +5,4 @@ There are few ways and things to consider in order to configure your AWS credent
 
 * http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html
 * http://docs.aws.amazon.com/general/latest/gr/aws-access-keys-best-practices.html
-* http://boto3.readthedocs.io/en/latest/guide/configuration.html
+* https://boto3.readthedocs.io/en/latest/guide/configuration.html

--- a/docs/_build/html/requirements.html
+++ b/docs/_build/html/requirements.html
@@ -60,7 +60,7 @@ file in the root of your lambda folder, and gordon will install all those using 
 <p>For more information about the format of this file:</p>
 <blockquote>
 <div><ul class="simple">
-<li><a class="reference external" href="https://pip.readthedocs.org/en/1.1/requirements.html">https://pip.readthedocs.org/en/1.1/requirements.html</a></li>
+<li><a class="reference external" href="https://pip.readthedocs.io/en/1.1/requirements.html">https://pip.readthedocs.io/en/1.1/requirements.html</a></li>
 </ul>
 </div></blockquote>
 <p>Additionally you can customize how gordon invoques <code class="docutils literal"><span class="pre">pip</span></code> using the following settings:</p>

--- a/docs/_build/html/setup_aws.html
+++ b/docs/_build/html/setup_aws.html
@@ -44,7 +44,7 @@
 <ul class="simple">
 <li><a class="reference external" href="http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html">http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html</a></li>
 <li><a class="reference external" href="http://docs.aws.amazon.com/general/latest/gr/aws-access-keys-best-practices.html">http://docs.aws.amazon.com/general/latest/gr/aws-access-keys-best-practices.html</a></li>
-<li><a class="reference external" href="http://boto3.readthedocs.io/en/latest/guide/configuration.html">http://boto3.readthedocs.io/en/latest/guide/configuration.html</a></li>
+<li><a class="reference external" href="https://boto3.readthedocs.io/en/latest/guide/configuration.html">https://boto3.readthedocs.io/en/latest/guide/configuration.html</a></li>
 </ul>
 </div>
 

--- a/docs/requirements.rst
+++ b/docs/requirements.rst
@@ -27,7 +27,7 @@ file in the root of your lambda folder, and gordon will install all those using 
 
 For more information about the format of this file:
 
-    * https://pip.readthedocs.org/en/1.1/requirements.html
+    * https://pip.readthedocs.io/en/1.1/requirements.html
 
 Additionally you can customize how gordon invoques ``pip`` using the following settings:
 

--- a/docs/setup_aws.rst
+++ b/docs/setup_aws.rst
@@ -5,4 +5,4 @@ There are few ways and things to consider in order to configure your AWS credent
 
 * http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html
 * http://docs.aws.amazon.com/general/latest/gr/aws-access-keys-best-practices.html
-* http://boto3.readthedocs.io/en/latest/guide/configuration.html
+* https://boto3.readthedocs.io/en/latest/guide/configuration.html

--- a/examples/apigateway/README.md
+++ b/examples/apigateway/README.md
@@ -1,7 +1,7 @@
 Apigateway Example
 ===========================
 
-![gordon](http://gordon.readthedocs.io/en/latest/_static/examples/apigateway.svg)
+![gordon](https://gordon.readthedocs.io/en/latest/_static/examples/apigateway.svg)
 
 This simple project defines one API Gateway called ``helloapi``and connects two
 lambdas: one written in python called ``helloapi`` and one written in javascript
@@ -13,8 +13,8 @@ This apigateway defines several resources (urls). Some of them are quite simple,
 other are quite more advanced like ``/404``, ``/http``, ``/mock`` and ``/complex/implementation``.
 
 Documentation relevant to this example:
- * [Lambdas](http://gordon.readthedocs.io/en/latest/lambdas.html)
- * [APIGateway](http://gordon.readthedocs.io/en/latest/eventsources/apigateway.html)
+ * [Lambdas](https://gordon.readthedocs.io/en/latest/lambdas.html)
+ * [APIGateway](https://gordon.readthedocs.io/en/latest/eventsources/apigateway.html)
 
 How to deploy it?
 ------------------

--- a/examples/cloudformation-custom-resources/README.md
+++ b/examples/cloudformation-custom-resources/README.md
@@ -15,7 +15,7 @@ You'll only need to deploy it and use the ``Arn``   as the ``ServiceToken`` of y
 ```
 
 Documentation relevant to this example:
- * [Lambdas](http://gordon.readthedocs.io/en/latest/lambdas.html)
+ * [Lambdas](https://gordon.readthedocs.io/en/latest/lambdas.html)
  * [AWS:Lambda-backed Custom Resources](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-custom-resources-lambda.html)
 
 How to deploy it?

--- a/examples/contexts/README.md
+++ b/examples/contexts/README.md
@@ -1,7 +1,7 @@
 Contexts Example
 ===========================
 
-![gordon](http://gordon.readthedocs.io/en/latest/_static/examples/contexts.svg)
+![gordon](https://gordon.readthedocs.io/en/latest/_static/examples/contexts.svg)
 
 This simple project defines three Lambdas called ``hellopy``, ``hellojs`` and ``hellojava``.
 Each of these lambdas are written in one different language, but they do pretty much the same.
@@ -26,10 +26,10 @@ These three lambdas defined within the application ``helloworld`` read the ``.co
 and return the value of the key ``bucket``.
 
 Documentation relevant to this example:
- * [Lambdas](http://gordon.readthedocs.io/en/latest/lambdas.html)
- * [Contexts](http://gordon.readthedocs.io/en/latest/contexts.html)
- * [Parameters](http://gordon.readthedocs.io/en/latest/parameters.html)
- * [Advanced Parameters](http://gordon.readthedocs.io/en/latest/parameters_advanced.html)
+ * [Lambdas](https://gordon.readthedocs.io/en/latest/lambdas.html)
+ * [Contexts](https://gordon.readthedocs.io/en/latest/contexts.html)
+ * [Parameters](https://gordon.readthedocs.io/en/latest/parameters.html)
+ * [Advanced Parameters](https://gordon.readthedocs.io/en/latest/parameters_advanced.html)
 
 How to deploy it?
 ------------------

--- a/examples/cron/README.md
+++ b/examples/cron/README.md
@@ -1,7 +1,7 @@
 Cron Example
 ===========================
 
-![gordon](http://gordon.readthedocs.io/en/latest/_static/examples/cron.svg)
+![gordon](https://gordon.readthedocs.io/en/latest/_static/examples/cron.svg)
 
 This simple project defines one lambda called ``hellopy``, and two CloudWatch rules called
 ``every_night`` and ``update_dns``.
@@ -12,8 +12,8 @@ This simple project defines one lambda called ``hellopy``, and two CloudWatch ru
 The lambda is quite dumb, and only prints the received event.
 
 Documentation relevant to this example:
- * [Lambdas](http://gordon.readthedocs.io/en/latest/lambdas.html)
- * [Events](http://gordon.readthedocs.io/en/latest/eventsources/events.html)
+ * [Lambdas](https://gordon.readthedocs.io/en/latest/lambdas.html)
+ * [Events](https://gordon.readthedocs.io/en/latest/eventsources/events.html)
 
 How to deploy it?
 ------------------

--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -7,7 +7,7 @@ In this example, we use [lambci/docker-lambda](https://github.com/lambci/docker-
 they are almost identical to the environment where the lambdas are going to run.
 
 Documentation relevant to this example:
- * [Lambdas](http://gordon.readthedocs.io/en/latest/lambdas.html)
+ * [Lambdas](https://gordon.readthedocs.io/en/latest/lambdas.html)
 
 How to deploy it?
 ------------------

--- a/examples/dynamodb/README.md
+++ b/examples/dynamodb/README.md
@@ -1,7 +1,7 @@
 Dynamodb Example
 ===========================
 
-![gordon](http://gordon.readthedocs.io/en/latest/_static/examples/dynamodb.svg)
+![gordon](https://gordon.readthedocs.io/en/latest/_static/examples/dynamodb.svg)
 
 This simple project defines one lambda called ``dynamoconsumer`` and integrates it with one dynamodb stream.
 
@@ -10,8 +10,8 @@ Every time 10 changes are published to the stream, the lambda will be executed.
 The lambda is quite dumb, and only prints the received event.
 
 Documentation relevant to this example:
- * [Lambdas](http://gordon.readthedocs.io/en/latest/lambdas.html)
- * [Dynamodb](http://gordon.readthedocs.io/en/latest/eventsources/dynamodb.html)
+ * [Lambdas](https://gordon.readthedocs.io/en/latest/lambdas.html)
+ * [Dynamodb](https://gordon.readthedocs.io/en/latest/eventsources/dynamodb.html)
 
 How to deploy it?
 ------------------

--- a/examples/go/README.md
+++ b/examples/go/README.md
@@ -10,4 +10,4 @@ Then, we only need to customize the ``build`` process of our lambda in order to 
 the Go source code, and... done!
 
 Documentation relevant to this example:
- * [Lambdas](http://gordon.readthedocs.io/en/latest/lambdas.html)
+ * [Lambdas](https://gordon.readthedocs.io/en/latest/lambdas.html)

--- a/examples/kinesis/README.md
+++ b/examples/kinesis/README.md
@@ -1,7 +1,7 @@
 Kinesis Example
 ===========================
 
-![gordon](http://gordon.readthedocs.io/en/latest/_static/examples/kinesis.svg)
+![gordon](https://gordon.readthedocs.io/en/latest/_static/examples/kinesis.svg)
 
 This simple project defines one lambda called ``kinesisconsumer`` and integrates it with one kinesis stream.
 
@@ -11,8 +11,8 @@ The lambda is quite dumb, and only prints the received event.
 
 
 Documentation relevant to this example:
- * [Lambdas](http://gordon.readthedocs.io/en/latest/lambdas.html)
- * [Kinesis](http://gordon.readthedocs.io/en/latest/eventsources/kinesis.html)
+ * [Lambdas](https://gordon.readthedocs.io/en/latest/lambdas.html)
+ * [Kinesis](https://gordon.readthedocs.io/en/latest/eventsources/kinesis.html)
 
 How to deploy it?
 ------------------

--- a/examples/modulejs/README.md
+++ b/examples/modulejs/README.md
@@ -21,8 +21,8 @@ file and will bundle them together before uploading your lambda to AWS.
 The lambda is quite dumb, and only and example.
 
 Documentation relevant to this example:
- * [Lambdas](http://gordon.readthedocs.io/en/latest/lambdas.html)
- * [Javascript Requirements](http://gordon.readthedocs.io/en/latest/requirements.html#javascript-requirements)
+ * [Lambdas](https://gordon.readthedocs.io/en/latest/lambdas.html)
+ * [Javascript Requirements](https://gordon.readthedocs.io/en/latest/requirements.html#javascript-requirements)
 
 How to deploy it?
 ------------------

--- a/examples/modulepython/README.md
+++ b/examples/modulepython/README.md
@@ -21,8 +21,8 @@ file and will bundle them together before uploading your lambda to AWS.
 The lambda is quite dumb, and only an example.
 
 Documentation relevant to this example:
- * [Lambdas](http://gordon.readthedocs.io/en/latest/lambdas.html)
- * [Python Requirements](http://gordon.readthedocs.io/en/latest/requirements.html#python-requirements)
+ * [Lambdas](https://gordon.readthedocs.io/en/latest/lambdas.html)
+ * [Python Requirements](https://gordon.readthedocs.io/en/latest/requirements.html#python-requirements)
 
 How to deploy it?
 ------------------

--- a/examples/s3/README.md
+++ b/examples/s3/README.md
@@ -1,7 +1,7 @@
 S3 Example
 ===========================
 
-![gordon](http://gordon.readthedocs.io/en/latest/_static/examples/s3.svg)
+![gordon](https://gordon.readthedocs.io/en/latest/_static/examples/s3.svg)
 
 This simple project defines one lambda called ``s3consumer``, and integrates it with a s3 bucket.
 
@@ -11,8 +11,8 @@ bucket (when objects are created or removed), our lambda ``s3consumer`` will be 
 The lambda itself is quite dumb, and only prints the received event.
 
 Documentation relevant to this example:
- * [Lambdas](http://gordon.readthedocs.io/en/latest/lambdas.html)
- * [S3](http://gordon.readthedocs.io/en/latest/eventsources/s3.html)
+ * [Lambdas](https://gordon.readthedocs.io/en/latest/lambdas.html)
+ * [S3](https://gordon.readthedocs.io/en/latest/eventsources/s3.html)
 
 How to deploy it?
 ------------------

--- a/examples/simplejava/README.md
+++ b/examples/simplejava/README.md
@@ -14,8 +14,8 @@ The lambda itself is quite dumb, and only prints information about the ``Hello W
 ```
 
 Documentation relevant to this example:
- * [Lambdas](http://gordon.readthedocs.io/en/latest/lambdas.html)
- * [Java Requirements](http://gordon.readthedocs.io/en/latest/requirements.html#java-requirements)
+ * [Lambdas](https://gordon.readthedocs.io/en/latest/lambdas.html)
+ * [Java Requirements](https://gordon.readthedocs.io/en/latest/requirements.html#java-requirements)
 
 How to deploy it?
 ------------------

--- a/examples/simplejs-es6/README.md
+++ b/examples/simplejs-es6/README.md
@@ -34,8 +34,8 @@ package it inside the ``.zip`` file of your lambda.
 
 
 Documentation relevant to this example:
- * [Lambdas](http://gordon.readthedocs.io/en/latest/lambdas.html)
- * [Lambdas Build](http://gordon.readthedocs.io/en/latest/lambdas.html#build)
+ * [Lambdas](https://gordon.readthedocs.io/en/latest/lambdas.html)
+ * [Lambdas Build](https://gordon.readthedocs.io/en/latest/lambdas.html#build)
 
 How to deploy it?
 ------------------

--- a/examples/simplejs/README.md
+++ b/examples/simplejs/README.md
@@ -14,8 +14,8 @@ The lambda itself is quite dumb, and only prints information about the ``Hello W
 ```
 
 Documentation relevant to this example:
- * [Lambdas](http://gordon.readthedocs.io/en/latest/lambdas.html)
- * [Javascript Requirements](http://gordon.readthedocs.io/en/latest/requirements.html#javascript-requirements)
+ * [Lambdas](https://gordon.readthedocs.io/en/latest/lambdas.html)
+ * [Javascript Requirements](https://gordon.readthedocs.io/en/latest/requirements.html#javascript-requirements)
 
 How to deploy it?
 ------------------

--- a/examples/simplepython/README.md
+++ b/examples/simplepython/README.md
@@ -14,8 +14,8 @@ The lambda itself is quite dumb, and only prints information about the ``Hello W
 ```
 
 Documentation relevant to this example:
- * [Lambdas](http://gordon.readthedocs.io/en/latest/lambdas.html)
- * [Python Requirements](http://gordon.readthedocs.io/en/latest/requirements.html#python-requirements)
+ * [Lambdas](https://gordon.readthedocs.io/en/latest/lambdas.html)
+ * [Python Requirements](https://gordon.readthedocs.io/en/latest/requirements.html#python-requirements)
 
 How to deploy it?
 ------------------

--- a/examples/simplescala/README.md
+++ b/examples/simplescala/README.md
@@ -6,8 +6,8 @@ This simple project defines one lambda called ``helloscala``.
 The lambda itself is quite dumb, and only prints ``Hello World``.
 
 Documentation relevant to this example:
- * [Lambdas](http://gordon.readthedocs.io/en/latest/lambdas.html)
- * [Java Requirements](http://gordon.readthedocs.io/en/latest/requirements.html#java-requirements)
+ * [Lambdas](https://gordon.readthedocs.io/en/latest/lambdas.html)
+ * [Java Requirements](https://gordon.readthedocs.io/en/latest/requirements.html#java-requirements)
  * [Gradle Scala Plugin](https://docs.gradle.org/current/userguide/scala_plugin.html)
 
 How to deploy it?

--- a/examples/slack/README.md
+++ b/examples/slack/README.md
@@ -6,7 +6,7 @@ lambda written in python called ``python_bot`` with the ``/my-python-bot-webhook
 
 If you configure a new slash command in your slack account to invoque this endpoint, you'll get something similar like this:
 
-![slack](http://gordon.readthedocs.io/en/latest/_static/examples/slack_demo.png)
+![slack](https://gordon.readthedocs.io/en/latest/_static/examples/slack_demo.png)
 
 In order to create your slash command in Slack, you'll need to follow a few steps:
 
@@ -18,8 +18,8 @@ In order to create your slash command in Slack, you'll need to follow a few step
 * Done! You should be able to use your slash command.
 
 Documentation relevant to this example:
- * [Lambdas](http://gordon.readthedocs.io/en/latest/lambdas.html)
- * [APIGateway](http://gordon.readthedocs.io/en/latest/eventsources/apigateway.html)
+ * [Lambdas](https://gordon.readthedocs.io/en/latest/lambdas.html)
+ * [APIGateway](https://gordon.readthedocs.io/en/latest/eventsources/apigateway.html)
  * [Slack Outgoing Webhooks](https://api.slack.com/outgoing-webhooks)
  * [Slack Icomming Webhooks](https://api.slack.com/incoming-webhooks)
  * [Slack Slash Commands](https://api.slack.com/slash-commands)

--- a/examples/snowplow/README.md
+++ b/examples/snowplow/README.md
@@ -10,8 +10,8 @@ Every time changes are published to the stream, the lambda will be executed. The
 the [Snowplow Analytics Python SDK](https://github.com/snowplow/snowplow-python-analytics-sdk) and do a simple update in a dynamodb table.
 
 Documentation relevant to this example:
- * [Lambdas](http://gordon.readthedocs.io/en/latest/lambdas.html)
- * [Kinesis](http://gordon.readthedocs.io/en/latest/eventsources/kinesis.html)
+ * [Lambdas](https://gordon.readthedocs.io/en/latest/lambdas.html)
+ * [Kinesis](https://gordon.readthedocs.io/en/latest/eventsources/kinesis.html)
 
 How to deploy it?
 ------------------

--- a/examples/telegram/README.md
+++ b/examples/telegram/README.md
@@ -1,7 +1,7 @@
 Telegram Example
 ===========================
 
-![gordon](http://gordon.readthedocs.io/en/latest/_static/examples/telegram.svg)
+![gordon](https://gordon.readthedocs.io/en/latest/_static/examples/telegram.svg)
 
 This project defines one API Gateway called ``telegramexampleapi`` and connects one
 lambda written in javascript called ``javascript_bot`` with the ``/my-js-bot-webhook`` url.
@@ -25,6 +25,6 @@ The bot is not very clever, and only replies saying ``Hello from gordon!``
 
 
 Documentation relevant to this example:
- * [Lambdas](http://gordon.readthedocs.io/en/latest/lambdas.html)
- * [APIGateway](http://gordon.readthedocs.io/en/latest/eventsources/apigateway.html)
+ * [Lambdas](https://gordon.readthedocs.io/en/latest/lambdas.html)
+ * [APIGateway](https://gordon.readthedocs.io/en/latest/eventsources/apigateway.html)
  * [Telegram API](https://core.telegram.org/)

--- a/examples/twilio/README.md
+++ b/examples/twilio/README.md
@@ -1,7 +1,7 @@
 Twilio Example
 ===========================
 
-![gordon](http://gordon.readthedocs.io/en/latest/_static/examples/twilio.svg)
+![gordon](https://gordon.readthedocs.io/en/latest/_static/examples/twilio.svg)
 
 This project defines one API Gateway called ``twilioexample``and connects one
 lambda written in python called ``helloworld`` with the ``/`` url.
@@ -23,6 +23,6 @@ in order to make the integration work:
 
 
 Documentation relevant to this example:
- * [Lambdas](http://gordon.readthedocs.io/en/latest/lambdas.html)
- * [APIGateway](http://gordon.readthedocs.io/en/latest/eventsources/apigateway.html)
+ * [Lambdas](https://gordon.readthedocs.io/en/latest/lambdas.html)
+ * [APIGateway](https://gordon.readthedocs.io/en/latest/eventsources/apigateway.html)
  * [TwiML Reference](https://www.twilio.com/docs/api/twiml)


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.