### PR TITLE
Use list_users to allow temp users

### DIFF
--- a/gordon/core.py
+++ b/gordon/core.py
@@ -452,7 +452,7 @@ class ProjectApply(ProjectApplyLoopBase):
         context = {
             'stage': self.stage,
             'aws_region': self.region,
-            'aws_account_id': boto3.client('iam').get_user()['User']['Arn'].split(':')[4],
+            'aws_account_id': boto3.client('iam').list_users(MaxItems=1)['Users'][0]['Arn'].split(':')[4],
             'env': os.environ
         }
 


### PR DESCRIPTION
When using non-user temp credentials, gordon has the following error from [when it tries to get the aws_account_id](https://github.com/jorgebastida/gordon/blob/master/gordon/core.py#L455):
```
botocore.exceptions.ClientError: An error occurred (ValidationError) when calling the GetUser operation: Must specify userName when calling with non-User credentials
```
Using `list_users` with a `MaxItems` of 1 should have a similar output, but allows for non-user credentials.

Fixes #33 