### PR TITLE
Allow S3 SSE for lambda objects

### DIFF
--- a/gordon/core.py
+++ b/gordon/core.py
@@ -35,6 +35,7 @@ AVAILABLE_RESOURCES = {
     'dynamodb': resources.dynamodb.Dynamodb,
     'kinesis': resources.kinesis.Kinesis,
     's3': resources.s3.BucketNotificationConfiguration,
+    's3encryptions': resources.s3encryptions.s3Encryption,
     'events': resources.events.CloudWatchEvent,
     'vpcs': resources.vpcs.Vpc,
     'contexts': resources.contexts.LambdasContexts,

--- a/gordon/resources/__init__.py
+++ b/gordon/resources/__init__.py
@@ -4,6 +4,7 @@ from . import dynamodb
 from . import lambdas
 from . import kinesis
 from . import s3
+from . import s3encryptions
 from . import events
 from . import vpcs
 from . import contexts

--- a/gordon/resources/s3encryptions.py
+++ b/gordon/resources/s3encryptions.py
@@ -1,0 +1,10 @@
+from .base import BaseResource
+
+
+class s3Encryption(BaseResource):
+
+    grn_type = 's3encryption'
+
+    required_settings = (
+        'type',
+    )

--- a/tests/apigateway/0001_project/_tests/0002_pr_r.json
+++ b/tests/apigateway/0001_project/_tests/0002_pr_r.json
@@ -11,7 +11,8 @@
             "context_to_inject": {},
             "filename": "code/contrib_helpers_sleep.zip",
             "key": "contrib_helpers_sleep.zip",
-            "name": "sleep-upload"
+            "name": "sleep-upload",
+            "s3encryption": {}
         },
         {
             "_type": "InjectContextAndUploadToS3",
@@ -23,7 +24,8 @@
             "context_to_inject": {},
             "filename": "code/contrib_lambdas_version.zip",
             "key": "contrib_lambdas_version.zip",
-            "name": "version-upload"
+            "name": "version-upload",
+            "s3encryption": {}
         },
         {
             "_type": "InjectContextAndUploadToS3",
@@ -35,7 +37,8 @@
             "context_to_inject": {},
             "filename": "code/pyexample_byepy.zip",
             "key": "pyexample_byepy.zip",
-            "name": "byepy-upload"
+            "name": "byepy-upload",
+            "s3encryption": {}
         },
         {
             "_type": "InjectContextAndUploadToS3",
@@ -47,7 +50,8 @@
             "context_to_inject": {},
             "filename": "code/pyexample_hellopy.zip",
             "key": "pyexample_hellopy.zip",
-            "name": "hellopy-upload"
+            "name": "hellopy-upload",
+            "s3encryption": {}
         }
     ],
     "outputs": {

--- a/tests/base/0001_project/_tests/0002_pr_r.json
+++ b/tests/base/0001_project/_tests/0002_pr_r.json
@@ -53,7 +53,8 @@
             "filename": "code/contrib_helpers_sleep.zip",
             "context_to_inject": {},
             "context_destinaton": ".context",
-            "key": "contrib_helpers_sleep.zip"
+            "key": "contrib_helpers_sleep.zip",
+            "s3encryption": {}
         },
         {
             "_type": "InjectContextAndUploadToS3",
@@ -65,7 +66,8 @@
             "filename": "code/contrib_lambdas_version.zip",
             "context_to_inject": {},
             "context_destinaton": ".context",
-            "key": "contrib_lambdas_version.zip"
+            "key": "contrib_lambdas_version.zip",
+            "s3encryption": {}
         }
     ],
     "parameters": {

--- a/tests/cron/0001_project/_tests/0002_pr_r.json
+++ b/tests/cron/0001_project/_tests/0002_pr_r.json
@@ -73,7 +73,8 @@
             "filename": "code/contrib_helpers_sleep.zip",
             "context_to_inject": {},
             "context_destinaton": ".context",
-            "key": "contrib_helpers_sleep.zip"
+            "key": "contrib_helpers_sleep.zip",
+            "s3encryption": {}
         },
         {
             "_type": "InjectContextAndUploadToS3",
@@ -85,7 +86,8 @@
             "filename": "code/contrib_lambdas_version.zip",
             "context_to_inject": {},
             "context_destinaton": ".context",
-            "key": "contrib_lambdas_version.zip"
+            "key": "contrib_lambdas_version.zip",
+            "s3encryption": {}
         },
         {
             "_type": "InjectContextAndUploadToS3",
@@ -97,7 +99,8 @@
             "filename": "code/cron_example.zip",
             "context_to_inject": {},
             "context_destinaton": ".context",
-            "key": "cron_example.zip"
+            "key": "cron_example.zip",
+            "s3encryption": {}
         }
     ],
     "parameters": {

--- a/tests/kinesisstream/0001_project/_tests/0002_pr_r.json
+++ b/tests/kinesisstream/0001_project/_tests/0002_pr_r.json
@@ -73,7 +73,8 @@
             "filename": "code/contrib_helpers_sleep.zip",
             "context_to_inject": {},
             "context_destinaton": ".context",
-            "key": "contrib_helpers_sleep.zip"
+            "key": "contrib_helpers_sleep.zip",
+            "s3encryption": {}
         },
         {
             "_type": "InjectContextAndUploadToS3",
@@ -85,7 +86,8 @@
             "filename": "code/contrib_lambdas_version.zip",
             "context_to_inject": {},
             "context_destinaton": ".context",
-            "key": "contrib_lambdas_version.zip"
+            "key": "contrib_lambdas_version.zip",
+            "s3encryption": {}
         },
         {
             "_type": "InjectContextAndUploadToS3",
@@ -97,7 +99,8 @@
             "filename": "code/kinesisconsumer_consumer.zip",
             "context_to_inject": {},
             "context_destinaton": ".context",
-            "key": "kinesisconsumer_consumer.zip"
+            "key": "kinesisconsumer_consumer.zip",
+            "s3encryption": {}
         }
     ],
     "parameters": {

--- a/tests/lambdajava/0001_project/_tests/0002_pr_r.json
+++ b/tests/lambdajava/0001_project/_tests/0002_pr_r.json
@@ -73,7 +73,8 @@
             "filename": "code/contrib_helpers_sleep.zip",
             "context_to_inject": {},
             "context_destinaton": ".context",
-            "key": "contrib_helpers_sleep.zip"
+            "key": "contrib_helpers_sleep.zip",
+            "s3encryption": {}
         },
         {
             "_type": "InjectContextAndUploadToS3",
@@ -85,7 +86,8 @@
             "filename": "code/contrib_lambdas_version.zip",
             "context_to_inject": {},
             "context_destinaton": ".context",
-            "key": "contrib_lambdas_version.zip"
+            "key": "contrib_lambdas_version.zip",
+            "s3encryption": {}
         },
         {
             "_type": "InjectContextAndUploadToS3",
@@ -97,7 +99,8 @@
             "filename": "code/javaexample_javaexample.zip",
             "context_to_inject": {},
             "context_destinaton": ".context",
-            "key": "javaexample_javaexample.zip"
+            "key": "javaexample_javaexample.zip",
+            "s3encryption": {}
         }
     ],
     "parameters": {

--- a/tests/lambdajs/0001_project/_tests/0002_pr_r.json
+++ b/tests/lambdajs/0001_project/_tests/0002_pr_r.json
@@ -73,7 +73,8 @@
             "filename": "code/contrib_helpers_sleep.zip",
             "context_to_inject": {},
             "context_destinaton": ".context",
-            "key": "contrib_helpers_sleep.zip"
+            "key": "contrib_helpers_sleep.zip",
+            "s3encryption": {}
         },
         {
             "_type": "InjectContextAndUploadToS3",
@@ -85,7 +86,8 @@
             "filename": "code/contrib_lambdas_version.zip",
             "context_to_inject": {},
             "context_destinaton": ".context",
-            "key": "contrib_lambdas_version.zip"
+            "key": "contrib_lambdas_version.zip",
+            "s3encryption": {}
         },
         {
             "_type": "InjectContextAndUploadToS3",
@@ -97,7 +99,8 @@
             "filename": "code/jsexample_jsexample.zip",
             "context_to_inject": {},
             "context_destinaton": ".context",
-            "key": "jsexample_jsexample.zip"
+            "key": "jsexample_jsexample.zip",
+            "s3encryption": {}
         }
     ],
     "parameters": {

--- a/tests/lambdapython/0001_project/_tests/0002_pr_r.json
+++ b/tests/lambdapython/0001_project/_tests/0002_pr_r.json
@@ -73,7 +73,8 @@
             "filename": "code/contrib_helpers_sleep.zip",
             "context_to_inject": {},
             "context_destinaton": ".context",
-            "key": "contrib_helpers_sleep.zip"
+            "key": "contrib_helpers_sleep.zip",
+            "s3encryption": {}
         },
         {
             "_type": "InjectContextAndUploadToS3",
@@ -85,7 +86,8 @@
             "filename": "code/contrib_lambdas_version.zip",
             "context_to_inject": {},
             "context_destinaton": ".context",
-            "key": "contrib_lambdas_version.zip"
+            "key": "contrib_lambdas_version.zip",
+            "s3encryption": {}
         },
         {
             "_type": "InjectContextAndUploadToS3",
@@ -97,7 +99,8 @@
             "filename": "code/pyexample_pyexample.zip",
             "context_to_inject": {},
             "context_destinaton": ".context",
-            "key": "pyexample_pyexample.zip"
+            "key": "pyexample_pyexample.zip",
+            "s3encryption": {}
         }
     ],
     "parameters": {

--- a/tests/projectupdate/0001_project/_tests/0002_pr_r.json
+++ b/tests/projectupdate/0001_project/_tests/0002_pr_r.json
@@ -73,7 +73,8 @@
             "filename": "code/contrib_helpers_sleep.zip",
             "context_to_inject": {},
             "context_destinaton": ".context",
-            "key": "contrib_helpers_sleep.zip"
+            "key": "contrib_helpers_sleep.zip",
+            "s3encryption": {}
         },
         {
             "_type": "InjectContextAndUploadToS3",
@@ -85,7 +86,8 @@
             "filename": "code/contrib_lambdas_version.zip",
             "context_to_inject": {},
             "context_destinaton": ".context",
-            "key": "contrib_lambdas_version.zip"
+            "key": "contrib_lambdas_version.zip",
+            "s3encryption": {}
         },
         {
             "_type": "InjectContextAndUploadToS3",
@@ -97,7 +99,8 @@
             "filename": "code/pyexample_pyexample.zip",
             "context_to_inject": {},
             "context_destinaton": ".context",
-            "key": "pyexample_pyexample.zip"
+            "key": "pyexample_pyexample.zip",
+            "s3encryption": {}
         }
     ],
     "parameters": {

--- a/tests/projectupdate/0002_project/_tests/0002_pr_r.json
+++ b/tests/projectupdate/0002_project/_tests/0002_pr_r.json
@@ -73,7 +73,8 @@
             "filename": "code/contrib_helpers_sleep.zip",
             "context_to_inject": {},
             "context_destinaton": ".context",
-            "key": "contrib_helpers_sleep.zip"
+            "key": "contrib_helpers_sleep.zip",
+            "s3encryption": {}
         },
         {
             "_type": "InjectContextAndUploadToS3",
@@ -85,7 +86,8 @@
             "filename": "code/contrib_lambdas_version.zip",
             "context_to_inject": {},
             "context_destinaton": ".context",
-            "key": "contrib_lambdas_version.zip"
+            "key": "contrib_lambdas_version.zip",
+            "s3encryption": {}
         },
         {
             "_type": "InjectContextAndUploadToS3",
@@ -97,7 +99,8 @@
             "filename": "code/pyexample_pyexample.zip",
             "context_to_inject": {},
             "context_destinaton": ".context",
-            "key": "pyexample_pyexample.zip"
+            "key": "pyexample_pyexample.zip",
+            "s3encryption": {}
         }
     ],
     "parameters": {


### PR DESCRIPTION
I'm not sure about the best way to do this - but figured I could start the conversation with this code and go from there.

I would like to be able to use S3's Server Side Encryption with gordon's lambda zipfile uploads in order to be more confident in config values being stored in them. This patch allows a project config to look like this:

```

---
project: myapp
default-region: us-east-1
code-bucket: gordon-myapp-d6e09dc9
upload-extra-args:
  ServerSideEncryption: 'aws:kms'
  SSEKMSKeyId: 'alias/testKey'
apps:
  - gordon.contrib.lambdas
  - myapp
```

The contents of `upload-extra-args` get mixed-in with the existing `ExtraArgs` from gordon and used in the `upload_file()` operation.

Concerns:
- `upload-extra-args` is an ugly key name - anyone have any suggestions?
- Is using `self.project.settings.get()` the right way to pull this value?
- `ServerSideEncryption: 'aws:kms'` requires SigV4 and boto didn't want to use that for s3 until I added:

```
s3 =
    signature_version = s3v4
```

 to my AWS config file.
