### PR TITLE
Prototype of rich CF types

### DIFF
--- a/gordon/core.py
+++ b/gordon/core.py
@@ -466,11 +466,13 @@ class ProjectApply(ProjectApplyLoopBase):
 
         for path in parameters_paths:
             if os.path.exists(path):
-                params = utils.load_settings(
-                    path,
-                    jinja2_enrich=True,
-                    protocols=protocols.BASE_APPLY_PROTOCOLS,
-                    context=context
+                params = utils.convert_cloudformation_types(
+                    utils.load_settings(
+                        path,
+                        jinja2_enrich=True,
+                        protocols=protocols.BASE_APPLY_PROTOCOLS,
+                        context=context
+                    )
                 )
                 parameters.update(params)
 

--- a/gordon/resources/lambdas.py
+++ b/gordon/resources/lambdas.py
@@ -254,6 +254,13 @@ class Lambda(base.BaseResource):
         extra = {}
         if self.settings.get('vpc'):
             vpc = self.project.get_resource('vpc::{}'.format(self.settings.get('vpc')))
+
+            if isinstance(vpc.settings['security-groups'], troposphere.Ref):
+                vpc.settings['security-groups']._type = 'List<AWS::EC2::SecurityGroup::Id>'
+
+            if isinstance(vpc.settings['subnet-ids'], troposphere.Ref):
+                vpc.settings['subnet-ids']._type = 'List<AWS::EC2::Subnet::Id>'
+
             extra['VpcConfig'] = awslambda.VPCConfig(
                 SecurityGroupIds=vpc.settings['security-groups'],
                 SubnetIds=vpc.settings['subnet-ids']

--- a/gordon/utils.py
+++ b/gordon/utils.py
@@ -183,6 +183,16 @@ def load_settings(filename, default=None, jinja2_enrich=False, context=None, pro
     return settings
 
 
+def convert_cloudformation_types(data):
+    cf_data = {}
+    for k, v in six.iteritems(data):
+        if isinstance(v, Iterable):
+            cf_data[k] = ', '.join(v)
+        else:
+            cf_data[k] = v
+    return cf_data
+
+
 def fix_troposphere_references(template):
     """"Tranverse the troposphere ``template`` looking missing references.
     Fix them by adding a new parameter for those references."""
@@ -194,7 +204,7 @@ def fix_troposphere_references(template):
                 template.add_parameter(
                     troposphere.Parameter(
                         name,
-                        Type="String",
+                        Type=getattr(value, '_type', 'String'),
                     )
                 )
 


### PR DESCRIPTION
Allow references to be rich types and not just plain strings.

This will allow to define vpc configuration like:

```yml
vpcs:
    default:
        security-groups: ref://MySecurityGroups
        subnet-ids: ref://MySubnets
```

And customize those values in using parameters doing:

```yml
---
MySecurityGroups:
    - a
    - b
    - c

MySubnets:
    - x
    - y
```