### PR TITLE
Add the ability to customize lambda function upload name

### DIFF
--- a/docs/lambdas.rst
+++ b/docs/lambdas.rst
@@ -87,6 +87,7 @@ The following is the anatomy of a lambda in gordon.
       timeout: { NUMBER }
       runtime: { RUNTIME_NAME }
       description: { STRING }
+      function-name: { STRING }
       build: { STRING }
       role: { MAP }
       vpc: { STRING }
@@ -305,6 +306,25 @@ Description                  Human-readable description for your lambda.
     hello_world:
       code: functions.py
       description: This is a really simple function which says hello
+
+
+function-name
+^^^^^^^^^^^^^^^^^^^^^^
+
+===========================  ============================================================================================================
+Name                         ``function-name``
+Required                     No
+Default                      *Empty*
+Valid types                  ``string``, ``reference``
+Description                  Base function name to upload to AWS
+===========================  ============================================================================================================
+
+.. code-block:: yaml
+
+  lambdas:
+    hello_world:
+      code: functions.py
+      function-name: goodbye_world
 
 
 .. _lambda-build:

--- a/gordon/exceptions.py
+++ b/gordon/exceptions.py
@@ -174,3 +174,7 @@ class LambdaNotFound(BaseGordonException):
 class ValidationError(BaseGordonException):
     hint = u"  Validation Error: {}"
     code = 24
+
+class InvalidLambdaFunctionName(BaseGordonException):
+    hint = u"Lambda {} cannot have name {}"
+    code = 25


### PR DESCRIPTION
This allows lambdas uploaded to gordon to contain a chosen base function
name, combined with "AWS::Region" and "Stage" references to keep
uniqueness across stages / regions.

While I believe this is a generally positive feature that allows for greater customization, my specific use case is a chain of three lambda functions, the first one invoking the second lambda multiple times, and each of those second lambda's invocations invoking the third lambda  once. With the current way that gordon deploys lambdas, their names all contain what I *believe* is the hexdigest of the lambda's zip file, making it hard to address gordon lambdas from within other lambdas.

This patch allows both `string`s and `Ref`s to be specified for the `function-name` config value, allowing applications to much more easily programmatically determine other lambdas' names via the contexts field.