### PR TITLE
Added ap-southeast-2 to list of lambda regions

### DIFF
--- a/gordon/core.py
+++ b/gordon/core.py
@@ -26,6 +26,7 @@ AWS_LAMBDA_REGIONS = (
     'eu-west-1',
     'eu-central-1',
     'ap-northeast-1',
+    'ap-southeast-2',
     'us-east-1',
     'us-west-2',
 )


### PR DESCRIPTION
As per https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services/ lambdas are now supported in Sydney (ap-southeast-2)