### PR TITLE
Add API Gateway IntegrationResponse header support

### DIFF
--- a/docs/eventsources/apigateway.rst
+++ b/docs/eventsources/apigateway.rst
@@ -349,7 +349,15 @@ Required                     No
 Valid Values                 ``list``
 Description                  The response that API Gateway provides after a method's back end completes processing a request.
                              API Gateway intercepts the integration's response so that you can control how API Gateway surfaces back-end
-                             responses.
+                             responses. Each response item can conatain the following keys: ``pattern``: a regular expression that
+                             specifies which error strings or status codes from the back end map to the integration response; ``code``:
+                             the status code that API Gateway uses to map the integration response to a MethodResponse status code;
+                             ``template``: the templates used to transform the integration response body; ``parameters``: the response
+                             parameters from the back-end response that API Gateway sends to the method response. Parameters can be used
+                             to set outbound CORS headers: ``method.response.header.Access-Control-Allow-Origin: "'*'"`` or to map custom
+                             dynamic headers: ``method.response.header.Custom: "integration.response.body.customValue"``
+
+
 ===========================  ============================================================================================================
 
 Example:
@@ -433,7 +441,25 @@ Full Example
                     responses:
                         - code: "200"
                           parameters:
-                            method.response.header.color: color
+                              method.response.header.color: color
+
+                /cors:
+                    methods: GET
+                    integration:
+                        lambda: helloworld.hellopy
+                        responses:
+                            - pattern: ""
+                              code: "200"
+                              parameters:
+                                  method.response.header.Access-Control-Allow-Origin: "'*'"
+                                  method.response.header.Access-Control-Allow-Methods: "'*'"
+                                  method.response.header.Access-Control-Request-Method: "'GET'"
+                    responses:
+                        - code: "200"
+                          parameters:
+                              method.response.header.Access-Control-Allow-Origin: true
+                              method.response.header.Access-Control-Allow-Methods: true
+                              method.response.header.Access-Control-Request-Method: true
 
                 /hi/complex/:
                     methods:

--- a/examples/apigateway/settings.yml
+++ b/examples/apigateway/settings.yml
@@ -48,6 +48,25 @@ apigateway:
                       parameters:
                         method.response.header.color: color
 
+            /cors:
+                # http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apitgateway-method-integration-integrationresponse.html
+                methods: GET
+                integration:
+                    lambda: helloworld.hellopy
+                    responses:
+                        - pattern: ""
+                          code: "200"
+                          parameters:
+                              method.response.header.Access-Control-Allow-Origin: "'*'"
+                              method.response.header.Access-Control-Allow-Methods: "'*'"
+                              method.response.header.Access-Control-Request-Method: "'GET'"
+                responses:
+                    - code: "200"
+                      parameters:
+                          method.response.header.Access-Control-Allow-Origin: true
+                          method.response.header.Access-Control-Allow-Methods: true
+                          method.response.header.Access-Control-Request-Method: true
+
             /shop/{item}:
                 methods: GET
                 integration:

--- a/gordon/resources/apigateway.py
+++ b/gordon/resources/apigateway.py
@@ -157,6 +157,8 @@ class ApiGateway(BaseResource):
         responses = []
         for response in resource['integration'].get('responses', default_integration_responses):
             extra = {}
+            if 'parameters' in response:
+                extra['ResponseParameters'] = response['parameters']
             if 'template' in response:
                 extra['ResponseTemplates'] = response['template']
             responses.append(


### PR DESCRIPTION
This adds support for static and dynamic IntegrationResponse headers as specified here: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apitgateway-method-integration-integrationresponse.html

The PR includes a CORS example and documentation for parameters within the Integration Response section.

I dug into the tests a bit, but didn't see an easy way to insert coverage. I'd love any direction/suggestions for adding test coverage.

https://github.com/jorgebastida/gordon/issues/68
