### PR TITLE
Removes overly strict validation.

### DIFF
--- a/gordon/resources/s3.py
+++ b/gordon/resources/s3.py
@@ -275,24 +275,6 @@ class BucketNotificationConfiguration(base.BaseResource):
         return bucket
 
     def _validate_notifications(self):
-        # Validate that notifications events don't overlap
-        top_events_for_bucket = set()
-        sub_events_for_top = defaultdict(list)
-        for notification_id, notification in six.iteritems(self._notifications):
-            for event, top, sub in notification.events:
-                if top in top_events_for_bucket or \
-                   top in sub_events_for_top or\
-                   sub in sub_events_for_top.get(top, []):
-                    raise exceptions.ResourceValidationError(
-                        (
-                            "Event {} overlaps with some other event "
-                            "registered for the same bucket."
-                        ).format(event)
-                    )
-                else:
-                    top_events_for_bucket.add(top)
-                    sub_events_for_top[top].append(sub)
-
         # Validate that all key prefix/suffix filters for a bucket
         # don't overlap one to each other.
         all_filters = defaultdict(list)


### PR DESCRIPTION
Two different triggers for two different lambda that use the same bucket/event are legal
as long as the prefix/suffix differ between the two triggers.

```
s3:
  on-new-upload:
    bucket: ref://receiptUploadBucket
    notifications:
      new-upload:
        lambda: new-upload-queue
        events:
          - s3:ObjectCreated:Put
        key_filters:
          prefix: 'v1/'
      new-upload-v2:
        lambda: new-upload-queue-v2
        events:
          - s3:ObjectCreated:Put
        key_filters:
          prefix: 'v2/'
```

The above should work as it can be configured by hand. However it fails due to the removed check. Enforcing uniqueness on filter criteria should be enough. 