### PR TITLE
Fixes bug where triggers don't show in UI.

### DIFF
--- a/gordon/resources/s3.py
+++ b/gordon/resources/s3.py
@@ -104,6 +104,7 @@ class LambdaFunctionNotification(BaseNotification):
                 FunctionName=self.get_destination_arn(),
                 Principal="s3.amazonaws.com",
                 SourceAccount=troposphere.Ref(troposphere.AWS_ACCOUNT_ID),
+                SourceArn=self.bucket_notification_configuration.get_bucket_arn()
             )
         )
 


### PR DESCRIPTION
Currently s3 triggers configured via gordon do not appear in the aws
lambda console. Instead the console throws an error when asked to display the
triggers.

This sets an optional parameter on the lambda Permission that allows the triggers
to display in the UI.

http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-permission.html