### PR TITLE
gordon apply --stage should accept capitalized letters as well

### DIFF
--- a/gordon/bin.py
+++ b/gordon/bin.py
@@ -11,7 +11,7 @@ from .exceptions import BaseGordonException
 
 def stage_validator(s):
     """Stage names must be between 2 and 16 characters long."""
-    if re.match(r'^[a-z0-9\-]{2,16}$', s):
+    if re.match(r'^[a-zA-Z0-9\-]{2,16}$', s):
         return s
     else:
         raise argparse.ArgumentTypeError("Stage names can only contain alphanumeric characters")


### PR DESCRIPTION
Ex: gordon apply --stage PROD
gordon [build | apply | startproject | startapp] apply: error: argument -s/--stage: Stage names can only contain alphanumeric characters

Expected:
gordon apply --stage PROD  to works