### PR TITLE
Fix formatting in Snowplow example README.md

### DIFF
--- a/examples/snowplow/README.md
+++ b/examples/snowplow/README.md
@@ -1,4 +1,5 @@
 Snowplow Example
+================
 
 This simple project defines one lambda called ``snowplowconsumer`` and integrates it with one kinesis stream.
 


### PR DESCRIPTION
'Snowplow Example' wasn't set as a title