### PR TITLE
Lazy generation of usage help

### DIFF
--- a/gordon/bin.py
+++ b/gordon/bin.py
@@ -21,7 +21,10 @@ def main(argv=None, stdin=None):
     stdin = stdin or sys.stdin
     argv = (argv or sys.argv)[1:]
 
-    parser = argparse.ArgumentParser(usage=("%(prog)s [build | apply | startproject | startapp]"))
+    parser = argparse.ArgumentParser()
+    parser.format_usage = lambda: (
+        "usage: gordon [%s]\n" % ' | '.join(parser._actions[1].choices.keys())
+    )
     subparsers = parser.add_subparsers()
 
     def add_default_arguments(p):


### PR DESCRIPTION
Instead having a string with all the possible actions for gordon, this
string is going to be generated with a lambda after the parser has all
the actions added to it.

Removing the usage kwarg to ArgumentParser we could achieve a similar
output:

    usage: gordon [-h] {startproject,startapp,build,apply,run,delete} ...

But to keep consistency with the previous output the lambda was added.