### PR TITLE
Add a --mvn flag that builds with mvn package

### DIFF
--- a/gordon/bin.py
+++ b/gordon/bin.py
@@ -35,7 +35,12 @@ def main(argv=None, stdin=None):
         p.add_argument("--debug",
                        dest="debug",
                        action="store_true",
-                       help="Verbose output for debugging purpouses.")
+                       help="Verbose output for debugging purposes.")
+
+        p.add_argument("--mvn",
+                       dest="mvn",
+                       action="store_true",
+                       help="use maven for packaging instead of gradle")
 
     startproject_parser = subparsers.add_parser('startproject', description='Start a new project')
     add_default_arguments(startproject_parser)

--- a/gordon/core.py
+++ b/gordon/core.py
@@ -107,6 +107,7 @@ class BaseProject(object):
         self.path = path
         self.stdin = stdin
         self.debug = kwargs.pop('debug', False)
+        self.mvn = kwargs.pop('mvn', False)
         self.build_path = os.path.join(self.path, '_build')
         self.root = os.path.dirname(os.path.abspath(__file__))
         self.settings = utils.load_settings(

--- a/gordon/resources/lambdas.py
+++ b/gordon/resources/lambdas.py
@@ -648,7 +648,10 @@ class JavaLambda(Lambda):
             return [['java/build/libs/java.jar', '_gloader.jar']]
 
     def _get_default_build_command(self, destination):
-        return "{gradle_path} build -Ptarget={target} {gradle_build_extra}"
+        if self.project.mvn:
+          return "mvn -DoutputDir={target} package"
+        else:
+          return "{gradle_path} build -Ptarget={target} {gradle_build_extra}"
 
     def _get_default_run_command(self):
         return 'java -cp "_gloader.jar:lib/*:." gordon.GordonLoader {handler} {name} {memory} {timeout}'


### PR DESCRIPTION
This assumes you have maven with an outputDir set for packaging that looks like gradle that takes an outputDir directory that is the temp directory generated by gordon.  Not sure where to put this documentation:

```
<build>
    <outputDirectory>${outputDir}</outputDirectory>
    <plugins>
      <plugin>
        <artifactId>maven-compiler-plugin</artifactId>
        <version>3.1</version>
        <configuration>
          <source>8</source>
          <target>8</target>
        </configuration>
      </plugin>
      <plugin>
        <groupId>org.apache.maven.plugins</groupId>
        <artifactId>maven-dependency-plugin</artifactId>
        <executions>
          <execution>
            <id>copy-dependencies</id>
            <phase>prepare-package</phase>
            <goals>
              <goal>copy-dependencies</goal>
            </goals>
            <configuration>
              <outputDirectory>${outputDir}/lib</outputDirectory>
              <includeScope>runtime</includeScope>
              <overWriteReleases>false</overWriteReleases>
              <overWriteSnapshots>true</overWriteSnapshots>
              <overWriteIfNewer>true</overWriteIfNewer>
            </configuration>
          </execution>
        </executions>
      </plugin>
    </plugins>
  </build>
```