### PR TITLE
apigateway docs contain an error regarding response patterns

### DIFF
--- a/docs/eventsources/apigateway.rst
+++ b/docs/eventsources/apigateway.rst
@@ -246,10 +246,10 @@ Example:
                     integration:
                         lambda: helloworld.sayhi
                         responses:
-                            - code: "404"
+                            - pattern: ""
+                              code: "404"
                     responses:
-                        - pattern: ""
-                          code: "404"
+                        - code: "404"
 
 
 Resource Parameters
@@ -366,8 +366,6 @@ Example:
               responses:
                 - pattern: ""
                   code: "404"
-                  models:
-                    application/xml: Empty
                   template:
                     application/json: |
                       #set($inputRoot = $input.path('$'))
@@ -400,10 +398,10 @@ Full Example
                     integration:
                         lambda: helloworld.sayhi
                         responses:
-                            - code: "404"
+                            - pattern: ""
+                              code: "404"
                     responses:
-                        - pattern: ""
-                          code: "404"
+                        - code: "404"
 
                 /hi/none:
                     method: GET


### PR DESCRIPTION
patterns are valid for integration responses, but not for resource responses.
