### PR TITLE
support ResponseParameters

### DIFF
--- a/docs/eventsources/apigateway.rst
+++ b/docs/eventsources/apigateway.rst
@@ -435,6 +435,19 @@ Full Example
                           parameters:
                             method.response.header.color: color
 
+                /redirect:
+                    methods: GET
+                    responses:
+                        - code: "302"
+                          parameters: method.response.header.Location: True
+                    integration:
+                        lambda: helloworld.redirection
+                        responses:
+                            - pattern: "^helloworld.RedirectError.*"
+                              code: "302"
+                              parameters:
+                                  method.response.header.Location: integration.response.body.cause.errorMessage
+
                 /hi/complex/:
                     methods:
                         GET:

--- a/gordon/resources/apigateway.py
+++ b/gordon/resources/apigateway.py
@@ -159,6 +159,8 @@ class ApiGateway(BaseResource):
             extra = {}
             if 'template' in response:
                 extra['ResponseTemplates'] = response['template']
+            if 'parameters' in response:
+                extra['ResponseParameters'] = response['parameters']
             responses.append(
                 IntegrationResponse(
                     SelectionPattern=six.text_type(response['pattern']),


### PR DESCRIPTION
API Gateway and troposphere support ResponseParameters e.g. to update headers; this PR adds support.

I needed this to support redirects:
https://aws.amazon.com/blogs/compute/redirection-in-a-serverless-api-with-aws-lambda-and-amazon-api-gateway/