### PR TITLE
Add Lambda Proxy integration to API Gateway

### DIFF
--- a/docs/eventsources/apigateway.rst
+++ b/docs/eventsources/apigateway.rst
@@ -419,6 +419,12 @@ Full Example
                     integration:
                         type: MOCK
 
+                /{integration+}:
+                    methods: POST
+                    integration:
+                        lambda: helloworld.sayho
+                        type: AWS_PROXY
+
                 /parameters:
                     methods: GET
                     parameters:

--- a/docs/eventsources/apigateway.rst
+++ b/docs/eventsources/apigateway.rst
@@ -300,7 +300,7 @@ Integration Type
 Name                         ``type``
 Required                     No
 Default                      AWS
-Valid Values                 ``AWS``, ``MOCK``, ``HTTP``
+Valid Values                 ``AWS``, ``AWS_PROXY``, ``MOCK``, ``HTTP``
 Description                  Type of the integration
 ===========================  ============================================================================================================
 


### PR DESCRIPTION
This adds support for AWS Proxy integration in API Gateway.

<img width="782" alt="screen shot 2016-10-19 at 15 56 52" src="https://cloud.githubusercontent.com/assets/147771/19521657/afb22234-9614-11e6-9255-0a90653cc5f3.png">
