### PR TITLE
Add missing AWS policies for auto-vpc-policy

### DIFF
--- a/gordon/resources/lambdas.py
+++ b/gordon/resources/lambdas.py
@@ -132,7 +132,9 @@ class Lambda(base.BaseResource):
                             {
                                 "Effect": "Allow",
                                 "Action": [
-                                    "ec2:CreateNetworkInterface"
+                                    "ec2:CreateNetworkInterface",
+                                    "ec2:DescribeNetworkInterfaces",
+                                    "ec2:DeleteNetworkInterface"
                                 ],
                                 "Resource": [
                                     "*"


### PR DESCRIPTION
When using `auto-vpc-policy` created role must have same policies of preconfigured `AWSLambdaENIManagementAccess` role.