### PR TITLE
Fix Python build settings for Docker

### DIFF
--- a/examples/docker/helloworld/settings.yml
+++ b/examples/docker/helloworld/settings.yml
@@ -8,11 +8,8 @@ lambdas:
             - cp -Rf * {target}
             - docker run --rm -v {target}:/var/task lambci/lambda:build npm install
 
-    # Note: pip support is not available at the moment
     # hellopython:
     #     code: hellopy
     #     runtime: python2.7
     #     handler: code.handler
-    #     build:
-    #       - cp -Rf * {target}
-    #       - docker run --rm -v {target}:/var/task lambci/lambda:build-python2.7 pip install -r requirements.txt -q -t {target}
+    #     pip-path: docker run --rm -v {target}:/var/task lambci/lambda:build-python2.7 pip


### PR DESCRIPTION
The current lambci/lambda:build-python2.7 Docker image includes pip and virtualenv
See issue #20