### PR TITLE
Allow specification of source account for S3 triggers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+0.7.1
+=======
+* Update S3 events to allow for different source accounts
+
 0.7.0
 =======
 * Add python 3.6 support (Thanks Brian Candler)

--- a/docs/eventsources/s3.rst
+++ b/docs/eventsources/s3.rst
@@ -45,6 +45,7 @@ Anatomy of the integration
            key_filters:
              prefix: { STRING }
              suffix: { STRING }
+           source_account: { ACCOUNT_ID }
 
 
 
@@ -215,6 +216,18 @@ Description                  Map of filters you want to apply
 Filters are optional to all notifications. The current AWS API only allows you to filter events by the key's ``prefix`` and ``suffix``. One notification can't define
 more than one of each (``prefix`` and ``suffix``) and  filters in a bucket can't overlap one to each other.``prefix`` and ``suffix`` value and can be either a ``string`` or a ``references``.
 
+Source Account
+^^^^^^^^^^^^^^^^^^^^^^
+
+===========================  ============================================================================================================
+Name                         ``source_account``
+Required                     No
+Valid types                  ``string``
+Description                  Account name where event will be triggered
+===========================  ============================================================================================================
+
+Source Accounts are optional to all notifications. If the ``source_account`` is not defined, it will default to the current account (resulting in a value of ``AWS::AccountId`` in the generated CloudFormation template)
+
 
 Full Example
 ----------------------------------
@@ -233,6 +246,7 @@ Full Example
           key_filters:
             prefix: cat_
             suffix: .png
+          source_account: 123456789012
 
         queue_on_remove_dog:
           queue: removed_dogs_queue

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ if sys.version_info < (2, 7):
 
 setup(
     name='gordon',
-    version='0.7.0',
+    version='0.7.1',
     url='http://github.com/jorgebastida/gordon',
     license='BSD',
     author='Jorge Bastida',


### PR DESCRIPTION
This has been used by our team successfully for over a year, and has allowed us to trigger a lambda function in account A from a bucket in account B.  A very simple change, but one that was very useful to us and may be useful to others.